### PR TITLE
docs: mark repository as DEPRECATED (V2 frozen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# ⚠️ DEPRECATED
+
+**This repository is no longer maintained.** The Arrakis V2 vault contracts
+remain deployed and immutable on-chain, but this codebase is frozen and will
+receive no further updates, fixes, or security patches.
+
+---
+
 # V2 Core
 
 Arrakis Vaults Version 2, Core Smart Contracts.


### PR DESCRIPTION
Adds a deprecation banner to the README, mirroring the V1 repos (vault-v1-core / vault-v1-periphery). The V2 vault contracts remain deployed and immutable on-chain; this codebase is frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)